### PR TITLE
Fix compiling OpenACC backend

### DIFF
--- a/core/src/OpenACC/Kokkos_OpenACC_Exec.hpp
+++ b/core/src/OpenACC/Kokkos_OpenACC_Exec.hpp
@@ -1033,13 +1033,14 @@ struct OpenACCReducerWrapper<BOr<Scalar, Space>, FunctorType,
   }
 };
 
-template <class Scalar, class Index, class Space, class FunctorType,
-          class TagType, class... Traits>
+template <class Scalar, class Space, class FunctorType, class TagType,
+          class... Traits>
 struct OpenACCReducerWrapper<MinLoc<Scalar, Space>, FunctorType,
                              Kokkos::RangePolicy<Traits...>, TagType> {
  private:
   using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using index_type  = typename std::remove_cv<
+      typename Kokkos::RangePolicy<Traits...>::index_type>::type;
 
  public:
   using value_type = ValLocScalar<scalar_type, index_type>;
@@ -1078,13 +1079,14 @@ struct OpenACCReducerWrapper<MinLoc<Scalar, Space>, FunctorType,
   }
 };
 
-template <class Scalar, class Index, class Space, class FunctorType,
-          class TagType, class... Traits>
+template <class Scalar, class Space, class FunctorType, class TagType,
+          class... Traits>
 struct OpenACCReducerWrapper<MaxLoc<Scalar, Space>, FunctorType,
                              Kokkos::RangePolicy<Traits...>, TagType> {
  private:
   using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using index_type  = typename std::remove_cv<
+      typename Kokkos::RangePolicy<Traits...>::index_type>::type;
 
  public:
   using value_type = ValLocScalar<scalar_type, index_type>;
@@ -1177,13 +1179,14 @@ struct OpenACCReducerWrapper<MinMax<Scalar, Space>, FunctorType,
   }
 };
 
-template <class Scalar, class Index, class Space, class FunctorType,
-          class TagType, class... Traits>
+template <class Scalar, class Space, class FunctorType, class TagType,
+          class... Traits>
 struct OpenACCReducerWrapper<MinMaxLoc<Scalar, Space>, FunctorType,
                              Kokkos::RangePolicy<Traits...>, TagType> {
  private:
   using scalar_type = typename std::remove_cv<Scalar>::type;
-  using index_type  = typename std::remove_cv<Index>::type;
+  using index_type  = typename std::remove_cv<
+      typename Kokkos::RangePolicy<Traits...>::index_type>::type;
 
  public:
   using value_type = MinMaxLocScalar<scalar_type, index_type>;

--- a/core/unit_test/TestViewAPI.hpp
+++ b/core/unit_test/TestViewAPI.hpp
@@ -1148,13 +1148,8 @@ class TestViewAPI {
 
     ASSERT_EQ(unmanaged_from_ptr_dx.span(),
               unsigned(N0) * unsigned(N1) * unsigned(N2) * unsigned(N3));
-#ifdef KOKKOS_ENABLE_OPENMPTARGET
-    return;
-#else
-#ifdef KOKKOS_ENABLE_OPENACC
-    return;
-#endif
-#endif
+// FIXME_OPENMPTARGET, FIXME_OPENACC
+#if !defined(KOKKOS_ENABLE_OPENMPTARGET) && !defined(KOKKOS_ENABLE_OPENACC)
     hx = Kokkos::create_mirror(dx);
     hy = Kokkos::create_mirror(dy);
 
@@ -1287,6 +1282,7 @@ class TestViewAPI {
     ASSERT_EQ(dx.data(), nullptr);
     ASSERT_EQ(dy.data(), nullptr);
     ASSERT_EQ(dz.data(), nullptr);
+#endif
   }
 
   static void run_test_deep_copy_empty() {

--- a/core/unit_test/TestWithoutInitializing.hpp
+++ b/core/unit_test/TestWithoutInitializing.hpp
@@ -216,17 +216,14 @@ TEST(TEST_CATEGORY, view_alloc_exec_space_int) {
   listen_tool_events(Config::DisableAll());
 }
 
+// FIXME_OPENACC The OpenACC backend doesn't implement ZeroMemset, can't skip
+// without "statement is unreachable" warning
+#ifndef KOKKOS_ENABLE_OPENACC
 TEST(TEST_CATEGORY, deep_copy_zero_memset) {
 // FIXME_OPENMPTARGET The OpenMPTarget backend doesn't implement ZeroMemset
 #ifdef KOKKOS_ENABLE_OPENMPTARGET
   if (std::is_same<typename TEST_EXECSPACE,
                    Kokkos::Experimental::OpenMPTarget>::value)
-    return;
-#endif
-// FIXME_OPENACC The OpenACC backend doesn't implement ZeroMemset
-#ifdef KOKKOS_ENABLE_OPENACC
-  if (std::is_same<typename TEST_EXECSPACE,
-                   Kokkos::Experimental::OpenACC>::value)
     return;
 #endif
 
@@ -245,3 +242,4 @@ TEST(TEST_CATEGORY, deep_copy_zero_memset) {
   ASSERT_TRUE(success);
   listen_tool_events(Config::DisableAll());
 }
+#endif


### PR DESCRIPTION
These are some changes that I needed to compile and run almost all tests successfully (openacc.execution_space_as_class_data_member was still failing).